### PR TITLE
jdk8 compartible version of aggregating-profiler

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,9 +184,14 @@ subprojects {
     }
 
     tasks {
+        withType<JavaCompile> {
+            sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+            targetCompatibility = JavaVersion.VERSION_1_8.toString()
+        }
+
         withType<KotlinCompile> {
             kotlinOptions {
-                jvmTarget = "1.8"
+                jvmTarget = JavaVersion.VERSION_1_8.toString()
             }
         }
         withType<Test> {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -50,8 +50,8 @@ object Libs {
     val okhttp_logging = "com.squareup.okhttp3:logging-interceptor:3.12.0"
     val awaitility = "org.awaitility:awaitility:3.1.4"
 
-    val dynamic_property_api = "ru.fix:dynamic-property-api:1.1.3"
-    val jfix_stdlib_concurrency = "ru.fix:jfix-stdlib-concurrency:1.0.59"
+    val dynamic_property_api = "ru.fix:dynamic-property-api:1.1.9-jdk8"
+    val jfix_stdlib_concurrency = "ru.fix:jfix-stdlib-concurrency:2.0.15-jdk8"
 
     val wiremock = "com.github.tomakehurst:wiremock:2.19.0"
 


### PR DESCRIPTION
Make aggregating-profiler compatible with jdk8. Will build on jdk11 with target bytecode 52 version (java 8 bytecode)